### PR TITLE
Implement collections admin item drawer workflow

### DIFF
--- a/components/CollectionsManager/CollectionsManager.tsx
+++ b/components/CollectionsManager/CollectionsManager.tsx
@@ -9,6 +9,7 @@ import {
   type AdminCollectionMetadata,
   filterCollectionItems,
   getItemSummary,
+  resolveCollectionViewState,
 } from "./collectionsManagerUtils";
 
 const emptyCollectionForm: AdminCollectionMetadata = {
@@ -112,7 +113,59 @@ export default function CollectionsManager() {
     };
   }, [itemDrawerOpen]);
 
-  const loadCollections = async (preferredSlug?: string | null) => {
+  const applyCollectionViewState = (
+    collections: AdminCollection[],
+    options: {
+      preferredCollectionSlug?: string | null;
+      preferredItemSlug?: string | null;
+      preserveItemSearch?: boolean;
+      preserveItemDrawer?: boolean;
+      preserveItemPreview?: boolean;
+      clearFeedback?: boolean;
+    } = {},
+  ) => {
+    const nextState = resolveCollectionViewState(collections, {
+      preferredCollectionSlug: options.preferredCollectionSlug,
+      selectedCollectionSlug,
+      preferredItemSlug: options.preferredItemSlug,
+      selectedItemSlug,
+      itemDrawerOpen,
+      itemPreview,
+      itemSearch,
+      preserveItemSearch: options.preserveItemSearch,
+      preserveItemDrawer: options.preserveItemDrawer,
+      preserveItemPreview: options.preserveItemPreview,
+    });
+
+    setSelectedCollectionSlug(nextState.selectedCollectionSlug);
+    setCollectionForm(nextState.selectedCollection?.metadata ?? emptyCollectionForm);
+    setSelectedItemSlug(nextState.selectedItemSlug);
+    setItemForm(
+      nextState.selectedItem ?? {
+        ...emptyItemForm,
+        collectionSlug: nextState.selectedCollectionSlug ?? "",
+      },
+    );
+    setItemDrawerOpen(nextState.itemDrawerOpen);
+    setItemPreview(nextState.itemPreview);
+    setItemSearch(nextState.itemSearch);
+
+    if (options.clearFeedback ?? true) {
+      setError(null);
+      setSuccess(null);
+    }
+  };
+
+  const loadCollections = async (
+    options: {
+      preferredCollectionSlug?: string | null;
+      preferredItemSlug?: string | null;
+      preserveItemSearch?: boolean;
+      preserveItemDrawer?: boolean;
+      preserveItemPreview?: boolean;
+      clearFeedback?: boolean;
+    } = {},
+  ) => {
     setLoadingCollections(true);
     setError(null);
 
@@ -128,18 +181,13 @@ export default function CollectionsManager() {
       );
 
       setCollectionsList(sorted);
-
-      const nextSlug = preferredSlug ?? selectedCollectionSlug;
-      if (!nextSlug) {
-        return;
-      }
-
-      const matched = sorted.find((collection) => collection.metadata.slug === nextSlug);
-      if (matched) {
-        selectCollection(matched);
-      } else {
-        startNewCollection();
-      }
+      applyCollectionViewState(sorted, {
+        ...options,
+        preferredCollectionSlug:
+          options.preferredCollectionSlug !== undefined
+            ? options.preferredCollectionSlug
+            : selectedCollectionSlug,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load collections");
     } finally {
@@ -196,13 +244,9 @@ export default function CollectionsManager() {
   };
 
   const selectCollection = (collection: AdminCollection) => {
-    setSelectedCollectionSlug(collection.metadata.slug);
-    setCollectionForm(collection.metadata);
-    resetItemEditor(collection.metadata.slug);
-    setItemDrawerOpen(false);
-    setItemSearch("");
-    setError(null);
-    setSuccess(null);
+    applyCollectionViewState(collectionsList, {
+      preferredCollectionSlug: collection.metadata.slug,
+    });
   };
 
   const startNewCollection = () => {
@@ -381,7 +425,10 @@ export default function CollectionsManager() {
         : "Collection created successfully.";
       setSuccess(successMessage);
       setSelectedCollectionSlug(savedSlug);
-      await loadCollections(savedSlug);
+      await loadCollections({
+        preferredCollectionSlug: savedSlug,
+        clearFeedback: false,
+      });
       setSuccess(successMessage);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save collection");
@@ -424,7 +471,10 @@ export default function CollectionsManager() {
       }
 
       startNewCollection();
-      await loadCollections(null);
+      await loadCollections({
+        preferredCollectionSlug: null,
+        clearFeedback: false,
+      });
       setSuccess("Collection deleted successfully.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete collection");
@@ -479,10 +529,14 @@ export default function CollectionsManager() {
         ? "Item updated successfully."
         : "Item created successfully.";
       setSuccess(successMessage);
-      await loadCollections(selectedCollectionSlug);
-      setSelectedItemSlug(savedItem.slug);
-      setItemForm(savedItem);
-      setItemDrawerOpen(true);
+      await loadCollections({
+        preferredCollectionSlug: selectedCollectionSlug,
+        preferredItemSlug: savedItem.slug,
+        preserveItemSearch: true,
+        preserveItemDrawer: true,
+        preserveItemPreview: true,
+        clearFeedback: false,
+      });
       setSuccess(successMessage);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save collection item");
@@ -525,9 +579,11 @@ export default function CollectionsManager() {
         throw new Error(errorData.error || "Failed to delete item");
       }
 
-      await loadCollections(selectedCollectionSlug);
-      resetItemEditor(selectedCollectionSlug);
-      setItemDrawerOpen(false);
+      await loadCollections({
+        preferredCollectionSlug: selectedCollectionSlug,
+        preserveItemSearch: true,
+        clearFeedback: false,
+      });
       setSuccess("Item deleted successfully.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete item");

--- a/components/CollectionsManager/CollectionsManager.tsx
+++ b/components/CollectionsManager/CollectionsManager.tsx
@@ -1,30 +1,15 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuthStore } from "@/lib/auth";
 import MarkdownRenderer from "@/components/MarkdownRenderer/MarkdownRenderer";
-
-type AdminCollectionMetadata = {
-  slug: string;
-  name: string;
-  description: string;
-  date: string;
-  image: string;
-};
-
-type AdminCollectionItem = {
-  collectionSlug: string;
-  slug: string;
-  title: string;
-  markdown: string;
-  image: string;
-  date: string;
-};
-
-type AdminCollection = {
-  metadata: AdminCollectionMetadata;
-  items: AdminCollectionItem[];
-};
+import {
+  type AdminCollection,
+  type AdminCollectionItem,
+  type AdminCollectionMetadata,
+  filterCollectionItems,
+  getItemSummary,
+} from "./collectionsManagerUtils";
 
 const emptyCollectionForm: AdminCollectionMetadata = {
   slug: "",
@@ -50,11 +35,8 @@ export default function CollectionsManager() {
   const [loadingCollections, setLoadingCollections] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const [selectedCollectionSlug, setSelectedCollectionSlug] = useState<
-    string | null
-  >(null);
-  const [collectionForm, setCollectionForm] =
-    useState<AdminCollectionMetadata>(emptyCollectionForm);
+  const [selectedCollectionSlug, setSelectedCollectionSlug] = useState<string | null>(null);
+  const [collectionForm, setCollectionForm] = useState<AdminCollectionMetadata>(emptyCollectionForm);
   const [collectionSubmitting, setCollectionSubmitting] = useState(false);
   const [collectionDeleting, setCollectionDeleting] = useState(false);
   const [itemForm, setItemForm] = useState<AdminCollectionItem>(emptyItemForm);
@@ -62,8 +44,9 @@ export default function CollectionsManager() {
   const [itemDeleting, setItemDeleting] = useState(false);
   const [itemPreview, setItemPreview] = useState(false);
   const [selectedItemSlug, setSelectedItemSlug] = useState<string | null>(null);
-  const [uploadingCollectionImage, setUploadingCollectionImage] =
-    useState(false);
+  const [itemDrawerOpen, setItemDrawerOpen] = useState(false);
+  const [itemSearch, setItemSearch] = useState("");
+  const [uploadingCollectionImage, setUploadingCollectionImage] = useState(false);
   const [uploadingItemImage, setUploadingItemImage] = useState(false);
   const [uploadingInlineImage, setUploadingInlineImage] = useState(false);
   const collectionCoverInputRef = useRef<HTMLInputElement>(null);
@@ -72,8 +55,7 @@ export default function CollectionsManager() {
   const itemTextAreaRef = useRef<HTMLTextAreaElement>(null);
   const isLocalBypassEnabled =
     typeof window !== "undefined" &&
-    (window.location.hostname === "localhost" ||
-      window.location.hostname === "127.0.0.1") &&
+    (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") &&
     process.env.NEXT_PUBLIC_DEV_ADMIN_BYPASS !== "false";
 
   const getAuthHeaders = (): Record<string, string> => {
@@ -108,6 +90,28 @@ export default function CollectionsManager() {
     getToken();
   }, [user]);
 
+  useEffect(() => {
+    if (!itemDrawerOpen) {
+      return;
+    }
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setItemDrawerOpen(false);
+      }
+    };
+
+    body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [itemDrawerOpen]);
+
   const loadCollections = async (preferredSlug?: string | null) => {
     setLoadingCollections(true);
     setError(null);
@@ -130,16 +134,14 @@ export default function CollectionsManager() {
         return;
       }
 
-      const matched = sorted.find((c) => c.metadata.slug === nextSlug);
+      const matched = sorted.find((collection) => collection.metadata.slug === nextSlug);
       if (matched) {
         selectCollection(matched);
       } else {
         startNewCollection();
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load collections",
-      );
+      setError(err instanceof Error ? err.message : "Failed to load collections");
     } finally {
       setLoadingCollections(false);
     }
@@ -159,9 +161,7 @@ export default function CollectionsManager() {
 
   const uploadImageFile = async (file: File) => {
     if (!authToken && !isLocalBypassEnabled) {
-      throw new Error(
-        "Authentication token not available. Please refresh the page.",
-      );
+      throw new Error("Authentication token not available. Please refresh the page.");
     }
 
     const formData = new FormData();
@@ -182,15 +182,25 @@ export default function CollectionsManager() {
     return data.url as string;
   };
 
-  const selectCollection = (collection: AdminCollection) => {
-    setSelectedCollectionSlug(collection.metadata.slug);
-    setCollectionForm(collection.metadata);
+  const resetItemEditor = (collectionSlug: string | null) => {
     setSelectedItemSlug(null);
     setItemForm({
       ...emptyItemForm,
-      collectionSlug: collection.metadata.slug,
+      collectionSlug: collectionSlug ?? "",
     });
     setItemPreview(false);
+  };
+
+  const closeItemDrawer = () => {
+    setItemDrawerOpen(false);
+  };
+
+  const selectCollection = (collection: AdminCollection) => {
+    setSelectedCollectionSlug(collection.metadata.slug);
+    setCollectionForm(collection.metadata);
+    resetItemEditor(collection.metadata.slug);
+    setItemDrawerOpen(false);
+    setItemSearch("");
     setError(null);
     setSuccess(null);
   };
@@ -198,33 +208,30 @@ export default function CollectionsManager() {
   const startNewCollection = () => {
     setSelectedCollectionSlug(null);
     setCollectionForm(emptyCollectionForm);
-    setSelectedItemSlug(null);
-    setItemForm(emptyItemForm);
-    setItemPreview(false);
+    resetItemEditor(null);
+    setItemDrawerOpen(false);
+    setItemSearch("");
     setError(null);
     setSuccess(null);
   };
 
-  const startNewItem = () => {
-    if (!selectedCollectionSlug && !collectionForm.slug) {
+  const openNewItemDrawer = () => {
+    if (!selectedCollectionSlug) {
       setError("Save the collection before adding items to it.");
       return;
     }
 
-    setSelectedItemSlug(null);
-    setItemForm({
-      ...emptyItemForm,
-      collectionSlug: selectedCollectionSlug || collectionForm.slug,
-    });
-    setItemPreview(false);
+    resetItemEditor(selectedCollectionSlug);
+    setItemDrawerOpen(true);
     setError(null);
     setSuccess(null);
   };
 
-  const selectItem = (item: AdminCollectionItem) => {
+  const openItemDrawer = (item: AdminCollectionItem) => {
     setSelectedItemSlug(item.slug);
     setItemForm(item);
     setItemPreview(false);
+    setItemDrawerOpen(true);
     setError(null);
     setSuccess(null);
   };
@@ -243,9 +250,7 @@ export default function CollectionsManager() {
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
     const nextMarkdown =
-      itemForm.markdown.slice(0, start) +
-      insertion +
-      itemForm.markdown.slice(end);
+      itemForm.markdown.slice(0, start) + insertion + itemForm.markdown.slice(end);
 
     setItemForm((prev) => ({ ...prev, markdown: nextMarkdown }));
 
@@ -256,9 +261,7 @@ export default function CollectionsManager() {
     });
   };
 
-  const handleCollectionImageUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleCollectionImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
@@ -272,14 +275,13 @@ export default function CollectionsManager() {
       setError(err instanceof Error ? err.message : "Failed to upload image");
     } finally {
       setUploadingCollectionImage(false);
-      if (collectionCoverInputRef.current)
+      if (collectionCoverInputRef.current) {
         collectionCoverInputRef.current.value = "";
+      }
     }
   };
 
-  const handleItemImageUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleItemImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
@@ -293,13 +295,13 @@ export default function CollectionsManager() {
       setError(err instanceof Error ? err.message : "Failed to upload image");
     } finally {
       setUploadingItemImage(false);
-      if (itemCoverInputRef.current) itemCoverInputRef.current.value = "";
+      if (itemCoverInputRef.current) {
+        itemCoverInputRef.current.value = "";
+      }
     }
   };
 
-  const handleInlineImageUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleInlineImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
     if (files.length === 0) return;
 
@@ -310,9 +312,7 @@ export default function CollectionsManager() {
       const snippets = await Promise.all(
         files.map(async (file) => {
           const url = await uploadImageFile(file);
-          const altText = file.name
-            .replace(/\.[^.]+$/, "")
-            .replace(/[-_]+/g, " ");
+          const altText = file.name.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ");
           return `![${altText}](${url})`;
         }),
       );
@@ -321,15 +321,24 @@ export default function CollectionsManager() {
       setError(err instanceof Error ? err.message : "Failed to upload image");
     } finally {
       setUploadingInlineImage(false);
-      if (inlineImageInputRef.current) inlineImageInputRef.current.value = "";
+      if (inlineImageInputRef.current) {
+        inlineImageInputRef.current.value = "";
+      }
     }
   };
 
   const currentCollection = selectedCollectionSlug
-    ? (collectionsList.find(
-        (c) => c.metadata.slug === selectedCollectionSlug,
-      ) ?? null)
+    ? (collectionsList.find((collection) => collection.metadata.slug === selectedCollectionSlug) ?? null)
     : null;
+  const canManageItems = Boolean(selectedCollectionSlug && currentCollection);
+  const filteredItems = useMemo(
+    () => filterCollectionItems(currentCollection?.items ?? [], itemSearch),
+    [currentCollection?.items, itemSearch],
+  );
+  const activeItem = useMemo(
+    () => currentCollection?.items.find((item) => item.slug === selectedItemSlug) ?? null,
+    [currentCollection, selectedItemSlug],
+  );
 
   const handleCollectionSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -344,12 +353,7 @@ export default function CollectionsManager() {
     setSuccess(null);
 
     try {
-      if (
-        !collectionForm.name ||
-        !collectionForm.slug ||
-        !collectionForm.description ||
-        !collectionForm.date
-      ) {
+      if (!collectionForm.name || !collectionForm.slug || !collectionForm.description || !collectionForm.date) {
         throw new Error("Please fill in all required collection fields");
       }
 
@@ -372,17 +376,15 @@ export default function CollectionsManager() {
 
       const payload = await response.json();
       const savedSlug = payload.data.slug as string;
-      setSuccess(
-        selectedCollectionSlug
-          ? "Collection updated successfully."
-          : "Collection created successfully.",
-      );
+      const successMessage = selectedCollectionSlug
+        ? "Collection updated successfully."
+        : "Collection created successfully.";
+      setSuccess(successMessage);
       setSelectedCollectionSlug(savedSlug);
       await loadCollections(savedSlug);
+      setSuccess(successMessage);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to save collection",
-      );
+      setError(err instanceof Error ? err.message : "Failed to save collection");
     } finally {
       setCollectionSubmitting(false);
     }
@@ -411,13 +413,10 @@ export default function CollectionsManager() {
     setSuccess(null);
 
     try {
-      const response = await fetch(
-        `/api/collections?slug=${encodeURIComponent(selectedCollectionSlug)}`,
-        {
-          method: "DELETE",
-          headers: getAuthHeaders(),
-        },
-      );
+      const response = await fetch(`/api/collections?slug=${encodeURIComponent(selectedCollectionSlug)}`, {
+        method: "DELETE",
+        headers: getAuthHeaders(),
+      });
 
       if (!response.ok) {
         const errorData = await response.json();
@@ -428,9 +427,7 @@ export default function CollectionsManager() {
       await loadCollections(null);
       setSuccess("Collection deleted successfully.");
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to delete collection",
-      );
+      setError(err instanceof Error ? err.message : "Failed to delete collection");
     } finally {
       setCollectionDeleting(false);
     }
@@ -439,8 +436,7 @@ export default function CollectionsManager() {
   const handleItemSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    const collectionSlug = selectedCollectionSlug || collectionForm.slug;
-    if (!collectionSlug) {
+    if (!selectedCollectionSlug) {
       setError("Save the collection before adding items to it.");
       return;
     }
@@ -456,26 +452,21 @@ export default function CollectionsManager() {
 
     try {
       if (!itemForm.title || !itemForm.slug || !itemForm.date) {
-        throw new Error(
-          "Please fill in all required item fields (title, slug, date)",
-        );
+        throw new Error("Please fill in all required item fields (title, slug, date)");
       }
 
-      const response = await fetch(
-        `/api/collections/${encodeURIComponent(collectionSlug)}/items`,
-        {
-          method: selectedItemSlug ? "PUT" : "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...getAuthHeaders(),
-          },
-          body: JSON.stringify({
-            ...itemForm,
-            collectionSlug,
-            originalSlug: selectedItemSlug,
-          }),
+      const response = await fetch(`/api/collections/${encodeURIComponent(selectedCollectionSlug)}/items`, {
+        method: selectedItemSlug ? "PUT" : "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...getAuthHeaders(),
         },
-      );
+        body: JSON.stringify({
+          ...itemForm,
+          collectionSlug: selectedCollectionSlug,
+          originalSlug: selectedItemSlug,
+        }),
+      });
 
       if (!response.ok) {
         const errorData = await response.json();
@@ -484,26 +475,24 @@ export default function CollectionsManager() {
 
       const payload = await response.json();
       const savedItem = payload.data as AdminCollectionItem;
-      setSuccess(
-        selectedItemSlug
-          ? "Item updated successfully."
-          : "Item created successfully.",
-      );
-      await loadCollections(collectionSlug);
+      const successMessage = selectedItemSlug
+        ? "Item updated successfully."
+        : "Item created successfully.";
+      setSuccess(successMessage);
+      await loadCollections(selectedCollectionSlug);
       setSelectedItemSlug(savedItem.slug);
       setItemForm(savedItem);
+      setItemDrawerOpen(true);
+      setSuccess(successMessage);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to save collection item",
-      );
+      setError(err instanceof Error ? err.message : "Failed to save collection item");
     } finally {
       setItemSubmitting(false);
     }
   };
 
   const handleItemDelete = async () => {
-    const collectionSlug = selectedCollectionSlug || collectionForm.slug;
-    if (!collectionSlug || !selectedItemSlug) {
+    if (!selectedCollectionSlug || !selectedItemSlug) {
       setError("Select an item to delete.");
       return;
     }
@@ -513,9 +502,7 @@ export default function CollectionsManager() {
       return;
     }
 
-    const confirmed = window.confirm(
-      `Delete item "${itemForm.title}"? This cannot be undone.`,
-    );
+    const confirmed = window.confirm(`Delete item "${itemForm.title}"? This cannot be undone.`);
     if (!confirmed) {
       return;
     }
@@ -526,7 +513,7 @@ export default function CollectionsManager() {
 
     try {
       const response = await fetch(
-        `/api/collections/${encodeURIComponent(collectionSlug)}/items?slug=${encodeURIComponent(selectedItemSlug)}`,
+        `/api/collections/${encodeURIComponent(selectedCollectionSlug)}/items?slug=${encodeURIComponent(selectedItemSlug)}`,
         {
           method: "DELETE",
           headers: getAuthHeaders(),
@@ -538,8 +525,9 @@ export default function CollectionsManager() {
         throw new Error(errorData.error || "Failed to delete item");
       }
 
-      await loadCollections(collectionSlug);
-      startNewItem();
+      await loadCollections(selectedCollectionSlug);
+      resetItemEditor(selectedCollectionSlug);
+      setItemDrawerOpen(false);
       setSuccess("Item deleted successfully.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete item");
@@ -548,493 +536,574 @@ export default function CollectionsManager() {
     }
   };
 
+  const panelTitle = selectedCollectionSlug ? `Managing items in /${selectedCollectionSlug}` : "Save a collection before adding items.";
+  const visibleCountLabel = currentCollection
+    ? `${filteredItems.length} of ${currentCollection.items.length} visible`
+    : "No collection selected";
+  const itemSummary = getItemSummary(itemForm.markdown);
+
   return (
-    <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)] text-[var(--text-light)]">
-      <aside className="rounded-xl border border-[var(--color-secondary)]/35 bg-black/25 p-4">
-        <div className="flex items-center justify-between gap-3 mb-4">
-          <div>
-            <h2 className="text-xl font-semibold text-[var(--color-primary)]">
-              Collections
-            </h2>
-            <p className="text-sm text-[var(--text-light)]/60">
-              Manage your collections
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={startNewCollection}
-            className="px-3 py-2 bg-[var(--color-primary)] text-[var(--text-color-dark)] rounded-md font-semibold cursor-pointer"
-          >
-            New
-          </button>
-        </div>
-
-        {loadingCollections ? (
-          <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
-            Loading collections...
-          </div>
-        ) : collectionsList.length === 0 ? (
-          <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
-            No collections yet.
-          </div>
-        ) : (
-          <div className="grid gap-3">
-            {collectionsList.map((collection) => {
-              const isActive =
-                collection.metadata.slug === selectedCollectionSlug;
-              return (
-                <button
-                  key={collection.metadata.slug}
-                  type="button"
-                  onClick={() => selectCollection(collection)}
-                  className={`rounded-lg border px-4 py-3 text-left transition ${
-                    isActive
-                      ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10"
-                      : "border-[var(--color-secondary)]/20 bg-black/20 hover:bg-black/35"
-                  }`}
-                >
-                  <p className="font-semibold text-[var(--color-primary)]">
-                    {collection.metadata.name}
-                  </p>
-                  <p className="text-sm text-[var(--text-light)]/60">
-                    /{collection.metadata.slug}
-                  </p>
-                  <p className="text-sm text-[var(--text-light)]/60">
-                    {collection.items.length} items
-                  </p>
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </aside>
-
-      <div className="grid gap-6">
-        {(error || success) && (
-          <div
-            className={`rounded-md border px-4 py-3 ${
-              error
-                ? "border-red-400/35 bg-red-500/10 text-red-200"
-                : "border-[var(--color-primary)]/35 bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
-            }`}
-          >
-            {error || success}
-          </div>
-        )}
-
-        <form
-          onSubmit={handleCollectionSubmit}
-          className="rounded-xl border border-[var(--color-secondary)]/35 bg-black/25 p-5 space-y-5"
-        >
-          <div>
-            <h3 className="text-xl font-semibold text-[var(--color-primary)]">
-              {selectedCollectionSlug ? "Edit Collection" : "Create Collection"}
-            </h3>
-            <p className="text-sm text-[var(--text-light)]/60 mt-1">
-              Collections display items in a vinyl-style carousel you can flip
-              through.
-            </p>
-          </div>
-
-          <div className="grid gap-5 md:grid-cols-2">
+    <>
+      <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)] text-[var(--text-light)]">
+        <aside className="rounded-xl border border-[var(--color-secondary)]/35 bg-black/25 p-4">
+          <div className="mb-4 flex items-center justify-between gap-3">
             <div>
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Collection Name
-              </label>
-              <input
-                type="text"
-                value={collectionForm.name}
-                onChange={(event) => {
-                  const name = event.target.value;
-                  setCollectionForm((prev) => ({
-                    ...prev,
-                    name,
-                    slug:
-                      !selectedCollectionSlug ||
-                      prev.slug === generateSlug(prev.name)
-                        ? generateSlug(name)
-                        : prev.slug,
-                  }));
-                }}
-                className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Slug
-              </label>
-              <input
-                type="text"
-                value={collectionForm.slug}
-                onChange={(event) =>
-                  setCollectionForm((prev) => ({
-                    ...prev,
-                    slug: event.target.value,
-                  }))
-                }
-                className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
-                required
-              />
-            </div>
-            <div className="md:col-span-2">
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Description
-              </label>
-              <textarea
-                value={collectionForm.description}
-                onChange={(event) =>
-                  setCollectionForm((prev) => ({
-                    ...prev,
-                    description: event.target.value,
-                  }))
-                }
-                className="w-full min-h-28 px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg resize-y"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Date
-              </label>
-              <input
-                type="date"
-                value={collectionForm.date}
-                onChange={(event) =>
-                  setCollectionForm((prev) => ({
-                    ...prev,
-                    date: event.target.value,
-                  }))
-                }
-                className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
-                required
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-              Collection Cover Image
-            </label>
-            <input
-              type="file"
-              ref={collectionCoverInputRef}
-              onChange={handleCollectionImageUpload}
-              accept="image/*"
-              disabled={uploadingCollectionImage}
-              className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg cursor-pointer"
-            />
-            <p className="text-sm text-[var(--text-light)]/60 mt-2">
-              {uploadingCollectionImage
-                ? "Uploading image..."
-                : "Upload a cover image for the collection."}
-            </p>
-            {collectionForm.image && (
-              <img
-                src={collectionForm.image}
-                alt="Collection cover preview"
-                className="mt-4 max-h-48 rounded border border-[var(--color-secondary)]/40"
-              />
-            )}
-          </div>
-
-          <div className="flex flex-wrap gap-3">
-            <button
-              type="submit"
-              disabled={collectionSubmitting}
-              className="px-5 py-2 bg-[var(--color-primary)] text-[var(--text-color-dark)] font-semibold rounded-md cursor-pointer disabled:opacity-60"
-            >
-              {collectionSubmitting
-                ? "Saving..."
-                : selectedCollectionSlug
-                  ? "Save Collection"
-                  : "Create Collection"}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (currentCollection) {
-                  selectCollection(currentCollection);
-                } else {
-                  startNewCollection();
-                }
-              }}
-              className="px-5 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-md cursor-pointer"
-            >
-              {selectedCollectionSlug ? "Reset" : "Clear"}
-            </button>
-            {selectedCollectionSlug && (
-              <button
-                type="button"
-                onClick={handleCollectionDelete}
-                disabled={collectionDeleting}
-                className="px-5 py-2 border border-red-400/50 bg-red-500/15 text-red-200 rounded-md cursor-pointer disabled:opacity-60"
-              >
-                {collectionDeleting ? "Deleting..." : "Delete Collection"}
-              </button>
-            )}
-          </div>
-        </form>
-
-        <div className="rounded-xl border border-[var(--color-secondary)]/35 bg-black/25 p-5 space-y-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h3 className="text-xl font-semibold text-[var(--color-primary)]">
-                Collection Items
-              </h3>
-              <p className="text-sm text-[var(--text-light)]/60">
-                {selectedCollectionSlug
-                  ? `Managing items in /${selectedCollectionSlug}`
-                  : "Save a collection before adding items."}
-              </p>
+              <h2 className="text-xl font-semibold text-[var(--color-primary)]">Collections</h2>
+              <p className="text-sm text-[var(--text-light)]/60">Manage your collections</p>
             </div>
             <button
               type="button"
-              onClick={startNewItem}
-              disabled={!selectedCollectionSlug && !collectionForm.slug}
-              className="px-4 py-2 bg-[var(--color-primary)] text-[var(--text-color-dark)] font-semibold rounded-md cursor-pointer disabled:opacity-50"
+              onClick={startNewCollection}
+              className="cursor-pointer rounded-md bg-[var(--color-primary)] px-3 py-2 font-semibold text-[var(--text-color-dark)]"
             >
-              New Item
+              New
             </button>
           </div>
 
-          {currentCollection && currentCollection.items.length > 0 ? (
-            <div className="grid gap-3">
-              {currentCollection.items
-                .slice()
-                .sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
-                .map((item) => {
-                  const isActive = item.slug === selectedItemSlug;
-                  return (
-                    <button
-                      key={item.slug}
-                      type="button"
-                      onClick={() => selectItem(item)}
-                      className={`rounded-lg border px-4 py-3 text-left transition flex items-center gap-3 ${
-                        isActive
-                          ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10"
-                          : "border-[var(--color-secondary)]/20 bg-black/20 hover:bg-black/35"
-                      }`}
-                    >
-                      {item.image && (
-                        <img
-                          src={item.image}
-                          alt={item.title}
-                          className="w-12 h-12 object-cover rounded"
-                        />
-                      )}
-                      <div>
-                        <p className="font-semibold text-[var(--color-primary)]">
-                          {item.title}
-                        </p>
-                        <p className="text-sm text-[var(--text-light)]/60">
-                          /{item.slug} &middot; {item.date}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })}
+          {loadingCollections ? (
+            <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
+              Loading collections...
+            </div>
+          ) : collectionsList.length === 0 ? (
+            <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
+              No collections yet.
             </div>
           ) : (
-            <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
-              {selectedCollectionSlug
-                ? "No items in this collection yet."
-                : "Create a collection first to start adding items."}
+            <div className="grid gap-3">
+              {collectionsList.map((collection) => {
+                const isActive = collection.metadata.slug === selectedCollectionSlug;
+                return (
+                  <button
+                    key={collection.metadata.slug}
+                    type="button"
+                    onClick={() => selectCollection(collection)}
+                    className={`rounded-lg border px-4 py-3 text-left transition ${
+                      isActive
+                        ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10"
+                        : "border-[var(--color-secondary)]/20 bg-black/20 hover:bg-black/35"
+                    }`}
+                  >
+                    <p className="font-semibold text-[var(--color-primary)]">{collection.metadata.name}</p>
+                    <p className="text-sm text-[var(--text-light)]/60">/{collection.metadata.slug}</p>
+                    <p className="text-sm text-[var(--text-light)]/60">{collection.items.length} items</p>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </aside>
+
+        <div className="grid gap-6">
+          {(error || success) && (
+            <div
+              className={`rounded-md border px-4 py-3 ${
+                error
+                  ? "border-red-400/35 bg-red-500/10 text-red-200"
+                  : "border-[var(--color-primary)]/35 bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
+              }`}
+            >
+              {error || success}
             </div>
           )}
 
           <form
-            onSubmit={handleItemSubmit}
-            className="grid gap-5 border-t border-[var(--color-secondary)]/20 pt-5"
+            onSubmit={handleCollectionSubmit}
+            className="space-y-5 rounded-xl border border-[var(--color-secondary)]/35 bg-black/25 p-5"
           >
-            <div className="flex items-center justify-between gap-3">
-              <h4 className="text-lg font-semibold text-[var(--color-secondary)]">
-                {selectedItemSlug ? "Edit Item" : "Create Item"}
-              </h4>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => inlineImageInputRef.current?.click()}
-                  disabled={uploadingInlineImage || !selectedCollectionSlug}
-                  className="px-3 py-1 border border-[var(--color-secondary)]/40 bg-black/35 rounded cursor-pointer disabled:opacity-50"
-                >
-                  {uploadingInlineImage ? "Uploading..." : "Insert Photo"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setItemPreview((prev) => !prev)}
-                  className="px-3 py-1 bg-[var(--color-primary)] text-[var(--text-color-dark)] rounded font-medium cursor-pointer"
-                >
-                  {itemPreview ? "Edit" : "Preview"}
-                </button>
-              </div>
+            <div>
+              <h3 className="text-xl font-semibold text-[var(--color-primary)]">
+                {selectedCollectionSlug ? "Edit Collection" : "Create Collection"}
+              </h3>
+              <p className="mt-1 text-sm text-[var(--text-light)]/60">
+                Collections display items in a vinyl-style carousel you can flip through.
+              </p>
             </div>
-
-            <input
-              type="file"
-              ref={inlineImageInputRef}
-              onChange={handleInlineImageUpload}
-              accept="image/*"
-              multiple
-              className="hidden"
-            />
 
             <div className="grid gap-5 md:grid-cols-2">
               <div>
-                <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                  Title
+                <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">
+                  Collection Name
                 </label>
                 <input
                   type="text"
-                  value={itemForm.title}
+                  value={collectionForm.name}
                   onChange={(event) => {
-                    const title = event.target.value;
-                    setItemForm((prev) => ({
+                    const name = event.target.value;
+                    setCollectionForm((prev) => ({
                       ...prev,
-                      title,
+                      name,
                       slug:
-                        !selectedItemSlug ||
-                        prev.slug === generateSlug(prev.title)
-                          ? generateSlug(title)
+                        !selectedCollectionSlug || prev.slug === generateSlug(prev.name)
+                          ? generateSlug(name)
                           : prev.slug,
                     }));
                   }}
-                  className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
+                  className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
                   required
-                  disabled={!selectedCollectionSlug}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                  Slug
-                </label>
+                <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">Slug</label>
                 <input
                   type="text"
-                  value={itemForm.slug}
+                  value={collectionForm.slug}
                   onChange={(event) =>
-                    setItemForm((prev) => ({
+                    setCollectionForm((prev) => ({
                       ...prev,
                       slug: event.target.value,
                     }))
                   }
-                  className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
+                  className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
                   required
-                  disabled={!selectedCollectionSlug}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">
+                  Description
+                </label>
+                <textarea
+                  value={collectionForm.description}
+                  onChange={(event) =>
+                    setCollectionForm((prev) => ({
+                      ...prev,
+                      description: event.target.value,
+                    }))
+                  }
+                  className="min-h-28 w-full resize-y rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
+                  required
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                  Date
-                </label>
+                <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">Date</label>
                 <input
                   type="date"
-                  value={itemForm.date}
+                  value={collectionForm.date}
                   onChange={(event) =>
-                    setItemForm((prev) => ({
+                    setCollectionForm((prev) => ({
                       ...prev,
                       date: event.target.value,
                     }))
                   }
-                  className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg"
+                  className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
                   required
-                  disabled={!selectedCollectionSlug}
                 />
               </div>
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Item Image (square cover)
+              <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">
+                Collection Cover Image
               </label>
               <input
                 type="file"
-                ref={itemCoverInputRef}
-                onChange={handleItemImageUpload}
+                ref={collectionCoverInputRef}
+                onChange={handleCollectionImageUpload}
                 accept="image/*"
-                disabled={uploadingItemImage || !selectedCollectionSlug}
-                className="w-full px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg cursor-pointer"
+                disabled={uploadingCollectionImage}
+                className="w-full cursor-pointer rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
               />
-              <p className="text-sm text-[var(--text-light)]/60 mt-2">
-                {uploadingItemImage
-                  ? "Uploading image..."
-                  : "Upload the main square cover image for this item (like album art)."}
+              <p className="mt-2 text-sm text-[var(--text-light)]/60">
+                {uploadingCollectionImage ? "Uploading image..." : "Upload a cover image for the collection."}
               </p>
-              {itemForm.image && (
+              {collectionForm.image && (
                 <img
-                  src={itemForm.image}
-                  alt="Item cover preview"
-                  className="mt-4 w-48 h-48 object-cover rounded border border-[var(--color-secondary)]/40"
+                  src={collectionForm.image}
+                  alt="Collection cover preview"
+                  className="mt-4 max-h-48 rounded border border-[var(--color-secondary)]/40"
                 />
-              )}
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium mb-2 text-[var(--color-secondary)]">
-                Description (Markdown)
-              </label>
-              {!itemPreview ? (
-                <textarea
-                  ref={itemTextAreaRef}
-                  value={itemForm.markdown}
-                  onChange={(event) =>
-                    setItemForm((prev) => ({
-                      ...prev,
-                      markdown: event.target.value,
-                    }))
-                  }
-                  className="w-full min-h-48 px-4 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-lg font-mono text-sm resize-y"
-                  disabled={!selectedCollectionSlug}
-                  placeholder="Optional notes or description for this item..."
-                />
-              ) : (
-                <div className="min-h-48 px-4 py-3 border border-[var(--color-secondary)]/40 bg-black/40 rounded-lg overflow-auto leading-7">
-                  <MarkdownRenderer content={itemForm.markdown} />
-                </div>
               )}
             </div>
 
             <div className="flex flex-wrap gap-3">
               <button
                 type="submit"
-                disabled={itemSubmitting || !selectedCollectionSlug}
-                className="px-5 py-2 bg-[var(--color-primary)] text-[var(--text-color-dark)] font-semibold rounded-md cursor-pointer disabled:opacity-50"
+                disabled={collectionSubmitting}
+                className="cursor-pointer rounded-md bg-[var(--color-primary)] px-5 py-2 font-semibold text-[var(--text-color-dark)] disabled:opacity-60"
               >
-                {itemSubmitting
+                {collectionSubmitting
                   ? "Saving..."
-                  : selectedItemSlug
-                    ? "Save Item"
-                    : "Create Item"}
+                  : selectedCollectionSlug
+                    ? "Save Collection"
+                    : "Create Collection"}
               </button>
               <button
                 type="button"
                 onClick={() => {
-                  const matchedItem = currentCollection?.items.find(
-                    (item) => item.slug === selectedItemSlug,
-                  );
-                  if (matchedItem) {
-                    selectItem(matchedItem);
+                  if (currentCollection) {
+                    selectCollection(currentCollection);
                   } else {
-                    startNewItem();
+                    startNewCollection();
                   }
                 }}
-                className="px-5 py-2 border border-[var(--color-secondary)]/40 bg-black/35 rounded-md cursor-pointer"
+                className="cursor-pointer rounded-md border border-[var(--color-secondary)]/40 bg-black/35 px-5 py-2"
               >
-                {selectedItemSlug ? "Reset" : "Clear"}
+                {selectedCollectionSlug ? "Reset" : "Clear"}
               </button>
-              {selectedItemSlug && (
+              {selectedCollectionSlug && (
                 <button
                   type="button"
-                  onClick={handleItemDelete}
-                  disabled={itemDeleting}
-                  className="px-5 py-2 border border-red-400/50 bg-red-500/15 text-red-200 rounded-md cursor-pointer disabled:opacity-60"
+                  onClick={handleCollectionDelete}
+                  disabled={collectionDeleting}
+                  className="cursor-pointer rounded-md border border-red-400/50 bg-red-500/15 px-5 py-2 text-red-200 disabled:opacity-60"
                 >
-                  {itemDeleting ? "Deleting..." : "Delete Item"}
+                  {collectionDeleting ? "Deleting..." : "Delete Collection"}
                 </button>
               )}
             </div>
           </form>
+
+          <section className="overflow-hidden rounded-xl border border-[var(--color-secondary)]/35 bg-black/25">
+            <div className="border-b border-[var(--color-secondary)]/20 bg-black/30 px-5 py-5 backdrop-blur">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold text-[var(--color-primary)]">Collection Items</h3>
+                  <p className="text-sm text-[var(--text-light)]/60">{panelTitle}</p>
+                </div>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <label className="min-w-[220px] flex-1 text-sm text-[var(--text-light)]/70">
+                    <span className="mb-2 block uppercase tracking-[0.18em] text-[var(--color-secondary)]/70">
+                      Scan Items
+                    </span>
+                    <input
+                      type="search"
+                      value={itemSearch}
+                      onChange={(event) => setItemSearch(event.target.value)}
+                      placeholder="Search by title, slug, or markdown"
+                      disabled={!canManageItems}
+                      className="w-full rounded-lg border border-[var(--color-secondary)]/35 bg-black/35 px-4 py-2 text-sm disabled:opacity-50"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={openNewItemDrawer}
+                    disabled={!canManageItems}
+                    className="cursor-pointer rounded-md bg-[var(--color-primary)] px-4 py-2 font-semibold text-[var(--text-color-dark)] shadow-[0_12px_30px_rgba(255,197,102,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    + New Item
+                  </button>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-[var(--text-light)]/55">
+                <span className="rounded-full border border-[var(--color-secondary)]/25 bg-black/25 px-3 py-1">
+                  {visibleCountLabel}
+                </span>
+                {activeItem && (
+                  <span className="rounded-full border border-[var(--color-primary)]/35 bg-[var(--color-primary)]/10 px-3 py-1 text-[var(--color-primary)]">
+                    Active: {activeItem.title}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="max-h-[min(68vh,46rem)] overflow-y-auto p-5">
+              {!canManageItems ? (
+                <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
+                  Create and save a collection first to start adding items.
+                </div>
+              ) : filteredItems.length > 0 ? (
+                <div className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
+                  {filteredItems.map((item) => {
+                    const isActive = item.slug === selectedItemSlug;
+                    const summary = getItemSummary(item.markdown);
+
+                    return (
+                      <button
+                        key={item.slug}
+                        type="button"
+                        onClick={() => openItemDrawer(item)}
+                        className={`group flex h-full flex-col rounded-xl border p-4 text-left transition ${
+                          isActive
+                            ? "border-[var(--color-primary)] bg-[var(--color-primary)]/10 shadow-[0_18px_45px_rgba(255,197,102,0.12)]"
+                            : "border-[var(--color-secondary)]/20 bg-black/20 hover:border-[var(--color-secondary)]/45 hover:bg-black/35"
+                        }`}
+                      >
+                        <div className="mb-4 flex items-start gap-3">
+                          {item.image ? (
+                            <img
+                              src={item.image}
+                              alt={item.title}
+                              className="h-16 w-16 shrink-0 rounded-lg border border-[var(--color-secondary)]/30 object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--color-secondary)]/30 bg-black/25 text-[10px] uppercase tracking-[0.22em] text-[var(--text-light)]/45">
+                              No Art
+                            </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-lg font-semibold text-[var(--color-primary)]">{item.title}</p>
+                            <p className="truncate text-sm text-[var(--text-light)]/60">/{item.slug}</p>
+                            <p className="mt-1 text-xs uppercase tracking-[0.18em] text-[var(--text-light)]/45">
+                              {item.date}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex-1 rounded-lg border border-[var(--color-secondary)]/15 bg-black/20 px-3 py-3 text-sm leading-6 text-[var(--text-light)]/72">
+                          {summary || "No markdown notes yet."}
+                        </div>
+                        <div className="mt-4 flex items-center justify-between text-xs uppercase tracking-[0.16em] text-[var(--text-light)]/50">
+                          <span>{item.markdown ? "Notes ready" : "Needs notes"}</span>
+                          <span className={isActive ? "text-[var(--color-primary)]" : "group-hover:text-[var(--text-light)]/75"}>
+                            {isActive && itemDrawerOpen ? "Editing" : "Open Drawer"}
+                          </span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="rounded-md border border-[var(--color-secondary)]/20 bg-black/20 px-4 py-6 text-[var(--text-light)]/70">
+                  {currentCollection?.items.length
+                    ? `No items match “${itemSearch}”.`
+                    : "No items in this collection yet. Add one from the sticky action above."}
+                </div>
+              )}
+            </div>
+          </section>
         </div>
       </div>
-    </div>
+
+      {itemDrawerOpen && (
+        <div className="fixed inset-0 z-40" role="dialog" aria-modal="true" aria-label="Collection item editor">
+          <button
+            type="button"
+            aria-label="Close item editor"
+            onClick={closeItemDrawer}
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+          />
+          <div className="relative ml-auto flex h-full w-full max-w-3xl flex-col border-l border-[var(--color-secondary)]/30 bg-[var(--color-dark)]/96 shadow-[-18px_0_45px_rgba(0,0,0,0.45)]">
+            <div className="border-b border-[var(--color-secondary)]/20 bg-black/35 px-5 py-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.24em] text-[var(--color-secondary)]/70">
+                    {currentCollection?.metadata.name || "Collection Item"}
+                  </p>
+                  <h4 className="mt-2 text-2xl font-semibold text-[var(--color-primary)]">
+                    {selectedItemSlug ? "Edit Item" : "Create Item"}
+                  </h4>
+                  <p className="mt-2 text-sm text-[var(--text-light)]/60">
+                    Work inside the drawer so the item list stays visible and compact behind it.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeItemDrawer}
+                  className="cursor-pointer rounded-md border border-[var(--color-secondary)]/35 bg-black/30 px-3 py-2 text-sm font-medium text-[var(--text-light)]/80"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+
+            <form onSubmit={handleItemSubmit} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <input
+                type="file"
+                ref={inlineImageInputRef}
+                onChange={handleInlineImageUpload}
+                accept="image/*"
+                multiple
+                className="hidden"
+              />
+
+              <div className="flex items-center justify-between gap-3 border-b border-[var(--color-secondary)]/15 bg-black/25 px-5 py-4">
+                <div>
+                  <p className="text-sm text-[var(--text-light)]/70">
+                    {selectedItemSlug ? `/${selectedItemSlug}` : "New item draft"}
+                  </p>
+                  {itemSummary && <p className="text-xs text-[var(--text-light)]/50">{itemSummary.slice(0, 90)}</p>}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => inlineImageInputRef.current?.click()}
+                    disabled={uploadingInlineImage || !canManageItems}
+                    className="cursor-pointer rounded-md border border-[var(--color-secondary)]/35 bg-black/35 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {uploadingInlineImage ? "Uploading..." : "Insert Photo"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setItemPreview((prev) => !prev)}
+                    className="cursor-pointer rounded-md bg-[var(--color-primary)] px-3 py-2 text-sm font-medium text-[var(--text-color-dark)]"
+                  >
+                    {itemPreview ? "Edit" : "Preview"}
+                  </button>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+                <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
+                  <div className="space-y-5">
+                    <div className="grid gap-5 md:grid-cols-2">
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">Title</label>
+                        <input
+                          type="text"
+                          value={itemForm.title}
+                          onChange={(event) => {
+                            const title = event.target.value;
+                            setItemForm((prev) => ({
+                              ...prev,
+                              title,
+                              slug:
+                                !selectedItemSlug || prev.slug === generateSlug(prev.title)
+                                  ? generateSlug(title)
+                                  : prev.slug,
+                            }));
+                          }}
+                          className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
+                          required
+                          disabled={!canManageItems}
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">Slug</label>
+                        <input
+                          type="text"
+                          value={itemForm.slug}
+                          onChange={(event) =>
+                            setItemForm((prev) => ({
+                              ...prev,
+                              slug: event.target.value,
+                            }))
+                          }
+                          className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
+                          required
+                          disabled={!canManageItems}
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-[var(--color-secondary)]">Date</label>
+                        <input
+                          type="date"
+                          value={itemForm.date}
+                          onChange={(event) =>
+                            setItemForm((prev) => ({
+                              ...prev,
+                              date: event.target.value,
+                            }))
+                          }
+                          className="w-full rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2"
+                          required
+                          disabled={!canManageItems}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <label className="block text-sm font-medium text-[var(--color-secondary)]">
+                          Description (Markdown)
+                        </label>
+                        <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-light)]/45">
+                          {itemPreview ? "Previewing" : "Editing"}
+                        </span>
+                      </div>
+                      {!itemPreview ? (
+                        <textarea
+                          ref={itemTextAreaRef}
+                          value={itemForm.markdown}
+                          onChange={(event) =>
+                            setItemForm((prev) => ({
+                              ...prev,
+                              markdown: event.target.value,
+                            }))
+                          }
+                          className="min-h-[340px] w-full resize-y rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-3 font-mono text-sm"
+                          disabled={!canManageItems}
+                          placeholder="Optional notes or description for this item..."
+                        />
+                      ) : (
+                        <div className="min-h-[340px] overflow-auto rounded-lg border border-[var(--color-secondary)]/40 bg-black/40 px-4 py-3 leading-7">
+                          <MarkdownRenderer content={itemForm.markdown} />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="space-y-5">
+                    <div className="rounded-xl border border-[var(--color-secondary)]/20 bg-black/20 p-4">
+                      <p className="text-xs uppercase tracking-[0.22em] text-[var(--color-secondary)]/70">
+                        Cover Image
+                      </p>
+                      <label className="mt-3 block text-sm font-medium text-[var(--text-light)]/75">
+                        Item Image (square cover)
+                      </label>
+                      <input
+                        type="file"
+                        ref={itemCoverInputRef}
+                        onChange={handleItemImageUpload}
+                        accept="image/*"
+                        disabled={uploadingItemImage || !canManageItems}
+                        className="mt-3 w-full cursor-pointer rounded-lg border border-[var(--color-secondary)]/40 bg-black/35 px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                      />
+                      <p className="mt-2 text-sm text-[var(--text-light)]/60">
+                        {uploadingItemImage
+                          ? "Uploading image..."
+                          : "Upload the main square cover image for this item."}
+                      </p>
+                      {itemForm.image ? (
+                        <img
+                          src={itemForm.image}
+                          alt="Item cover preview"
+                          className="mt-4 aspect-square w-full rounded-lg border border-[var(--color-secondary)]/30 object-cover"
+                        />
+                      ) : (
+                        <div className="mt-4 flex aspect-square w-full items-center justify-center rounded-lg border border-dashed border-[var(--color-secondary)]/25 bg-black/25 text-xs uppercase tracking-[0.22em] text-[var(--text-light)]/40">
+                          Cover Preview
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="rounded-xl border border-[var(--color-secondary)]/20 bg-black/20 p-4 text-sm text-[var(--text-light)]/70">
+                      <p className="text-xs uppercase tracking-[0.22em] text-[var(--color-secondary)]/70">Workflow</p>
+                      <ul className="mt-3 space-y-3 leading-6">
+                        <li>• Keep the drawer open while scanning the bounded list behind it.</li>
+                        <li>• Use search above the grid to jump straight to long collections.</li>
+                        <li>• Insert inline images without leaving the markdown field.</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border-t border-[var(--color-secondary)]/20 bg-black/35 px-5 py-4">
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="submit"
+                    disabled={itemSubmitting || !canManageItems}
+                    className="cursor-pointer rounded-md bg-[var(--color-primary)] px-5 py-2 font-semibold text-[var(--text-color-dark)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {itemSubmitting ? "Saving..." : selectedItemSlug ? "Save Item" : "Create Item"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (activeItem) {
+                        openItemDrawer(activeItem);
+                      } else if (selectedCollectionSlug) {
+                        resetItemEditor(selectedCollectionSlug);
+                      }
+                    }}
+                    className="cursor-pointer rounded-md border border-[var(--color-secondary)]/40 bg-black/35 px-5 py-2"
+                  >
+                    {selectedItemSlug ? "Reset" : "Clear"}
+                  </button>
+                  {selectedItemSlug && (
+                    <button
+                      type="button"
+                      onClick={handleItemDelete}
+                      disabled={itemDeleting}
+                      className="cursor-pointer rounded-md border border-red-400/50 bg-red-500/15 px-5 py-2 text-red-200 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {itemDeleting ? "Deleting..." : "Delete Item"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/components/CollectionsManager/collectionsManagerUtils.ts
+++ b/components/CollectionsManager/collectionsManagerUtils.ts
@@ -1,0 +1,65 @@
+export type AdminCollectionMetadata = {
+  slug: string;
+  name: string;
+  description: string;
+  date: string;
+  image: string;
+};
+
+export type AdminCollectionItem = {
+  collectionSlug: string;
+  slug: string;
+  title: string;
+  markdown: string;
+  image: string;
+  date: string;
+};
+
+export type AdminCollection = {
+  metadata: AdminCollectionMetadata;
+  items: AdminCollectionItem[];
+};
+
+const normalizeText = (value: string) => value.toLowerCase().trim();
+
+const parseTimestamp = (value: string) => {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+export const sortCollectionItems = (items: AdminCollectionItem[]) =>
+  [...items].sort((left, right) => {
+    const dateDifference = parseTimestamp(right.date) - parseTimestamp(left.date);
+
+    if (dateDifference !== 0) {
+      return dateDifference;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+
+export const getItemSearchText = (item: AdminCollectionItem) =>
+  normalizeText([item.title, item.slug, item.date, item.markdown].join(" "));
+
+export const filterCollectionItems = (
+  items: AdminCollectionItem[],
+  query: string,
+) => {
+  const normalizedQuery = normalizeText(query);
+
+  if (!normalizedQuery) {
+    return sortCollectionItems(items);
+  }
+
+  return sortCollectionItems(items).filter((item) =>
+    getItemSearchText(item).includes(normalizedQuery),
+  );
+};
+
+export const getItemSummary = (markdown: string) =>
+  markdown
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/[`*_>#~-]/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();

--- a/components/CollectionsManager/collectionsManagerUtils.ts
+++ b/components/CollectionsManager/collectionsManagerUtils.ts
@@ -20,6 +20,29 @@ export type AdminCollection = {
   items: AdminCollectionItem[];
 };
 
+export type ResolvedCollectionViewState = {
+  selectedCollection: AdminCollection | null;
+  selectedCollectionSlug: string | null;
+  selectedItem: AdminCollectionItem | null;
+  selectedItemSlug: string | null;
+  itemDrawerOpen: boolean;
+  itemPreview: boolean;
+  itemSearch: string;
+};
+
+type ResolveCollectionViewStateOptions = {
+  preferredCollectionSlug?: string | null;
+  selectedCollectionSlug?: string | null;
+  preferredItemSlug?: string | null;
+  selectedItemSlug?: string | null;
+  itemDrawerOpen: boolean;
+  itemPreview: boolean;
+  itemSearch: string;
+  preserveItemSearch?: boolean;
+  preserveItemDrawer?: boolean;
+  preserveItemPreview?: boolean;
+};
+
 const normalizeText = (value: string) => value.toLowerCase().trim();
 
 const parseTimestamp = (value: string) => {
@@ -40,6 +63,53 @@ export const sortCollectionItems = (items: AdminCollectionItem[]) =>
 
 export const getItemSearchText = (item: AdminCollectionItem) =>
   normalizeText([item.title, item.slug, item.date, item.markdown].join(" "));
+
+export const resolveCollectionViewState = (
+  collections: AdminCollection[],
+  options: ResolveCollectionViewStateOptions,
+): ResolvedCollectionViewState => {
+  const nextCollectionSlug =
+    options.preferredCollectionSlug !== undefined
+      ? options.preferredCollectionSlug
+      : options.selectedCollectionSlug ?? null;
+
+  const selectedCollection = nextCollectionSlug
+    ? collections.find((collection) => collection.metadata.slug === nextCollectionSlug) ?? null
+    : null;
+
+  if (!selectedCollection) {
+    return {
+      selectedCollection: null,
+      selectedCollectionSlug: null,
+      selectedItem: null,
+      selectedItemSlug: null,
+      itemDrawerOpen: false,
+      itemPreview: false,
+      itemSearch: "",
+    };
+  }
+
+  const candidateItemSlug =
+    options.preferredItemSlug !== undefined
+      ? options.preferredItemSlug
+      : options.preserveItemDrawer
+        ? options.selectedItemSlug ?? null
+        : null;
+  const selectedItem = candidateItemSlug
+    ? selectedCollection.items.find((item) => item.slug === candidateItemSlug) ?? null
+    : null;
+  const keepDrawerOpen = Boolean(options.preserveItemDrawer && options.itemDrawerOpen && selectedItem);
+
+  return {
+    selectedCollection,
+    selectedCollectionSlug: selectedCollection.metadata.slug,
+    selectedItem,
+    selectedItemSlug: selectedItem?.slug ?? null,
+    itemDrawerOpen: keepDrawerOpen,
+    itemPreview: Boolean(keepDrawerOpen && options.preserveItemPreview && options.itemPreview),
+    itemSearch: options.preserveItemSearch ? options.itemSearch : "",
+  };
+};
 
 export const filterCollectionItems = (
   items: AdminCollectionItem[],

--- a/tests/collectionsManagerUtils.test.ts
+++ b/tests/collectionsManagerUtils.test.ts
@@ -3,7 +3,9 @@ import test from 'node:test';
 import {
   filterCollectionItems,
   getItemSummary,
+  resolveCollectionViewState,
   sortCollectionItems,
+  type AdminCollection,
   type AdminCollectionItem,
 } from '../components/CollectionsManager/collectionsManagerUtils';
 
@@ -31,6 +33,38 @@ const items: AdminCollectionItem[] = [
     markdown: 'Finale with ![cover](/cover.jpg) [liner notes](/notes).',
     image: '',
     date: '2025-02-01',
+  },
+];
+
+const collections: AdminCollection[] = [
+  {
+    metadata: {
+      slug: 'records',
+      name: 'Records',
+      description: 'Main collection',
+      date: '2025-02-01',
+      image: '/images/records.jpg',
+    },
+    items,
+  },
+  {
+    metadata: {
+      slug: 'mixtapes',
+      name: 'Mixtapes',
+      description: 'Secondary collection',
+      date: '2025-01-01',
+      image: '/images/mixtapes.jpg',
+    },
+    items: [
+      {
+        collectionSlug: 'mixtapes',
+        slug: 'demo',
+        title: 'Demo',
+        markdown: 'Rough cut.',
+        image: '',
+        date: '2024-05-01',
+      },
+    ],
   },
 ];
 
@@ -63,4 +97,86 @@ test('getItemSummary strips markdown formatting and image syntax', () => {
     getItemSummary('Finale with ![cover](/cover.jpg) [liner notes](/notes).'),
     'Finale with liner notes.',
   );
+});
+
+test('resolveCollectionViewState preserves item drawer context after a save refresh', () => {
+  const refreshedCollections: AdminCollection[] = [
+    {
+      ...collections[0],
+      items: collections[0].items.map((item) =>
+        item.slug === 'anthem'
+          ? {
+              ...item,
+              slug: 'anthem-remix',
+              title: 'Anthem Remix',
+            }
+          : item,
+      ),
+    },
+    collections[1],
+  ];
+
+  const result = resolveCollectionViewState(refreshedCollections, {
+    preferredCollectionSlug: 'records',
+    preferredItemSlug: 'anthem-remix',
+    selectedCollectionSlug: 'records',
+    selectedItemSlug: 'anthem',
+    itemDrawerOpen: true,
+    itemPreview: true,
+    itemSearch: 'anthem',
+    preserveItemSearch: true,
+    preserveItemDrawer: true,
+    preserveItemPreview: true,
+  });
+
+  assert.equal(result.selectedCollectionSlug, 'records');
+  assert.equal(result.selectedItemSlug, 'anthem-remix');
+  assert.equal(result.selectedItem?.title, 'Anthem Remix');
+  assert.equal(result.itemDrawerOpen, true);
+  assert.equal(result.itemPreview, true);
+  assert.equal(result.itemSearch, 'anthem');
+});
+
+test('resolveCollectionViewState preserves search but closes the drawer after delete refresh', () => {
+  const refreshedCollections: AdminCollection[] = [
+    {
+      ...collections[0],
+      items: collections[0].items.filter((item) => item.slug !== 'anthem'),
+    },
+    collections[1],
+  ];
+
+  const result = resolveCollectionViewState(refreshedCollections, {
+    preferredCollectionSlug: 'records',
+    selectedCollectionSlug: 'records',
+    selectedItemSlug: 'anthem',
+    itemDrawerOpen: true,
+    itemPreview: true,
+    itemSearch: 'anthem',
+    preserveItemSearch: true,
+  });
+
+  assert.equal(result.selectedCollectionSlug, 'records');
+  assert.equal(result.selectedItemSlug, null);
+  assert.equal(result.selectedItem, null);
+  assert.equal(result.itemDrawerOpen, false);
+  assert.equal(result.itemPreview, false);
+  assert.equal(result.itemSearch, 'anthem');
+});
+
+test('resolveCollectionViewState resets item context when switching collections', () => {
+  const result = resolveCollectionViewState(collections, {
+    preferredCollectionSlug: 'mixtapes',
+    selectedCollectionSlug: 'records',
+    selectedItemSlug: 'anthem',
+    itemDrawerOpen: true,
+    itemPreview: true,
+    itemSearch: 'anthem',
+  });
+
+  assert.equal(result.selectedCollectionSlug, 'mixtapes');
+  assert.equal(result.selectedItemSlug, null);
+  assert.equal(result.itemDrawerOpen, false);
+  assert.equal(result.itemPreview, false);
+  assert.equal(result.itemSearch, '');
 });

--- a/tests/collectionsManagerUtils.test.ts
+++ b/tests/collectionsManagerUtils.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  filterCollectionItems,
+  getItemSummary,
+  sortCollectionItems,
+  type AdminCollectionItem,
+} from '../components/CollectionsManager/collectionsManagerUtils';
+
+const items: AdminCollectionItem[] = [
+  {
+    collectionSlug: 'records',
+    slug: 'deep-cut',
+    title: 'Deep Cut',
+    markdown: 'A hidden favorite with layered **notes**.',
+    image: '/images/deep-cut.jpg',
+    date: '2024-01-10',
+  },
+  {
+    collectionSlug: 'records',
+    slug: 'anthem',
+    title: 'Anthem',
+    markdown: 'The loud opener.',
+    image: '/images/anthem.jpg',
+    date: '2025-02-01',
+  },
+  {
+    collectionSlug: 'records',
+    slug: 'closer',
+    title: 'Closer',
+    markdown: 'Finale with ![cover](/cover.jpg) [liner notes](/notes).',
+    image: '',
+    date: '2025-02-01',
+  },
+];
+
+test('sortCollectionItems orders by newest date and then title', () => {
+  const sorted = sortCollectionItems(items);
+
+  assert.deepEqual(
+    sorted.map((item) => item.slug),
+    ['anthem', 'closer', 'deep-cut'],
+  );
+});
+
+test('filterCollectionItems matches title, slug, and markdown content', () => {
+  assert.deepEqual(
+    filterCollectionItems(items, 'favorite').map((item) => item.slug),
+    ['deep-cut'],
+  );
+  assert.deepEqual(
+    filterCollectionItems(items, 'closer').map((item) => item.slug),
+    ['closer'],
+  );
+  assert.deepEqual(
+    filterCollectionItems(items, '').map((item) => item.slug),
+    ['anthem', 'closer', 'deep-cut'],
+  );
+});
+
+test('getItemSummary strips markdown formatting and image syntax', () => {
+  assert.equal(
+    getItemSummary('Finale with ![cover](/cover.jpg) [liner notes](/notes).'),
+    'Finale with liner notes.',
+  );
+});


### PR DESCRIPTION
## Summary
- replace the long inline collections item editor with a bounded searchable item grid and fixed right-side drawer
- keep existing collection management UI intact while preserving item create/edit/delete, image upload, inline image insertion, markdown preview, and feedback states
- add utility coverage for item sorting, filtering, and markdown summary cleanup

## Validation
- npm run lint
- npm test
- npm run build

## Notes
- npm run build still logs the existing Netlify Blobs environment warnings during prerender, but the build completes successfully
